### PR TITLE
Added support for visible whitespace character (Fix #9)

### DIFF
--- a/typing-trainer.py
+++ b/typing-trainer.py
@@ -82,6 +82,7 @@ def create_word_list():
             words = f.readlines()
             for word in words:
                 word = word.strip()
+                word = word.replace(' ', u'\u00b7')
                 if len(word) >= MIN_WORD_LENGTH and len(word) <= MAX_WORD_LENGTH:
                     word_list.append(word.upper())
     except:
@@ -115,7 +116,9 @@ def add_words(cycle, game_words, num_words, total_chars, word_list):
 # Check if typed letter is at start of word and update word
 def check_letter_of_word(letter, game_words):
     for word in list(game_words):
-        if letter == word.word[0].lower():
+        first_char = word.word[0].lower()
+        first_char = " " if first_char == u"\u00b7" else first_char
+        if letter == first_char:
             word.update_word()
             if word.word == " ":
                 if SOUND:


### PR DESCRIPTION
Replaced the whitespace character ` ` with the character `·`. The `·` character is used to denote whitespace in many text and code editors.

This change may look better on a different `FONT` in which `·` is vertically centralized and can hence be distinguished easily from the `.` period character. Testing using the Consolas font looked good.